### PR TITLE
fixing RF3 version check

### DIFF
--- a/GlyphBrowser.roboFontExt/info.plist
+++ b/GlyphBrowser.roboFontExt/info.plist
@@ -28,7 +28,7 @@
 	<key>timeStamp</key>
 	<real>1520758385.31</real>
 	<key>version</key>
-	<string>2.5.3</string>
+	<string>2.5.4</string>
 	<key>com.robofontmechanic.Mechanic</key>
 	<dict>
 		<key>repository</key>

--- a/GlyphBrowser.roboFontExt/lib/browser.py
+++ b/GlyphBrowser.roboFontExt/lib/browser.py
@@ -4,10 +4,10 @@ import os
 import unicodeRangeNames
 
 from mojo.roboFont import version
-if version >= "3.0.0":
+if version >= "3.0":
     from importlib import reload
 reload(unicodeRangeNames)
-    
+
 
 
 from pprint import pprint


### PR DESCRIPTION
the check `if version >= "3.0.0"` returns `True` in the RF3 beta (RoboFontPy3.app, version `3.0b`), but returns `False` in the public RF3 release (RoboFont3.app, version `3.0`).

- the first commit fixes the check to `version >= "3.0.0"`, so it returns `True` as intended
- the second commit touches the version number, so the update is picked up by Mechanic
