### PR TITLE
Reset the font window glyph collection query when closing the Glyph Browser window

### DIFF
--- a/GlyphBrowser.roboFontExt/lib/browser.py
+++ b/GlyphBrowser.roboFontExt/lib/browser.py
@@ -913,6 +913,7 @@ class Browser(object):
         self.w.addGlyphPanelButton.enable(False)
         self.w.toSpaceCenter.enable(False)
         self.update()
+        self.w.bind("close", self.windowClosing)
         self.w.open()
         self.w.catNames.setSelection([0])
     
@@ -1046,6 +1047,10 @@ class Browser(object):
         #items = [dict(name=name) for name in self.catNames]
         self.w.catNames.set(items)
         self.checkSampleSize()
+    
+    def windowClosing(self, sender):
+        # Reset the font window glyph collection query
+        CurrentFontWindow().getGlyphCollection().setQuery(None)
 
     def callbackLookup(self, sender=None):
         lookupThese = []


### PR DESCRIPTION
The glyph collection in the CurrentFontWindow is left in a state from the last query from the GlyphBrowser. It's necessary to reset the query when the Glyph Browser window is shown, otherwise glyphs remain hidden.